### PR TITLE
Integrate some of Blair's comments and changes

### DIFF
--- a/paper/appendix.tex
+++ b/paper/appendix.tex
@@ -308,7 +308,7 @@ See Table~\ref{tab:completeness}.
   \end{tabular}
   \caption{  \label{tab:gyrAcounts}%
    Bin and neighborhood gyrA protein content. gyrA count for each bin is the number
-    of gyrA amino acid sequences part of the original bin. gyrA count by \plass is
+    of gyrA amino acid sequences that are part of the original bin. gyrA count by \plass is
     the minimum number of gyrA amino acid sequences supported by at least one
     position with at least 10 copies of each variant, e.g. ``3'' indicates that
     there is at least one position in the multiple sequence alignment of gyrA
@@ -391,7 +391,9 @@ this conservative approach.
 
 \label{subsec:othergenes}
 
-See bin and neighborhood content results for {\em alaS} in Table~\ref{tab:alaS}, {\em gyrB} in Table~\ref{tab:gyrB}, {\em recA} in Table~\ref{tab:recA}, rpb2d6 in Table~\ref{tab:rpb2d6}, {\em rplB} in Table~\ref{tab:rplB}, and {\em rpsC} in Table~\ref{tab:rpsC}. We selected gyrB and
+See bin and neighborhood content results for alaS in Table~\ref{tab:alaS}, gyrB in 
+Table~\ref{tab:gyrB}, recA in Table~\ref{tab:recA}, rpb2d6 in Table~\ref{tab:rpb2d6}, 
+rplB in Table~\ref{tab:rplB}, and rpsC in Table~\ref{tab:rpsC}. We selected gyrB and
 recA because they were used by \hu to assign taxonomy to binned genomes. We selected
 other genes used as single copy orthologs by programs like CheckM, and with longer PFAM
 domains. 

--- a/paper/matmethods.tex
+++ b/paper/matmethods.tex
@@ -51,12 +51,15 @@ index it. We then perform neighborhood queries with \sgc, which
 produces a set of cDBG nodes and reads that contributed to them.  The
 full list of query genomes for the {\em Proteiniclasticum} query is
   available in Supp Material \ref{subsec:query_accessions}, and
-  the NCBI accessions for the {\em P. gingivalis}, {\em T. denticola}, and {\em B. thetaiotamicron} queries are in the directory {\tt pipeline-base} of the paper repository, files {\tt strain-gingivalis.txt}, {\tt strain-denticola.txt}, and {\tt strain-bacteroides.txt}, respectively.
+  the NCBI accessions for the {\em P. gingivalis}, {\em T. denticola}, 
+and {\em B. thetaiotamicron} queries are in the directory {\tt pipeline-base} 
+of the paper repository, files {\tt strain-gingivalis.txt}, 
+{\tt strain-denticola.txt}, and {\tt strain-bacteroides.txt}, respectively.
 
 \subsection*{Search results analysis}
 
 Query neighborhood size, Jaccard containment, and Jaccard similarity
-was estimated using modulo hash signatures with a k-mer size of 31 and
+were estimated using modulo hash signatures with a k-mer size of 31 and
 a scaled factor of 1000, as implemented in sourmash v2.0a9
 \cite{sourmash}.
 
@@ -86,9 +89,9 @@ identical amino acids in the alignment divided by the number of
 overlapping residues between the sequences. Pairwise distances were
 visualized using a multidimensional scaling calculated in R using the
 {\tt cmdscale} function. To visualize the assembly graph structure
-underlying these amino acid assemblies, we use paladin v1.3.1 
+underlying these amino acid assemblies, we used paladin v1.3.1 
 to map abundance-trimmed reads back to the \plass amino acid assembly,
-with the {\tt -f} argument set to 125 to set the minimum ORF length accepted \cite{paladin}. 
+with {\tt -f 125} to set the minimum ORF length accepted \cite{paladin}. 
 We extracted the reads that mapped to the gene of interest, created an
 assembly graph using BCALM v2.2.0 \cite{chikhi2016compacting}, and
 visualized the graph using Bandage v0.8.1 \cite{bandage}. We colored

--- a/paper/matmethods.tex
+++ b/paper/matmethods.tex
@@ -47,7 +47,7 @@ long degree-two paths when possible.
 \subsection*{Neighborhood indexing and search}
 
 We used \sgc to build an $r$-dominating set for each denoised cDBG and
-index it. We then perform neighborhood queries with \sgc, which
+index it. We then performed neighborhood queries with \sgc, which
 produces a set of cDBG nodes and reads that contributed to them.  The
 full list of query genomes for the {\em Proteiniclasticum} query is
   available in Supp Material \ref{subsec:query_accessions}, and


### PR DESCRIPTION
Adds some changes suggested by @bdsullivan in 2019_01_10_09_18_48.pdf, particularly in the materials and methods section and the appendix. 

@ctb I did not address comments about migrating repo, fig 4a, and supp mat references in the materials and methods section. 